### PR TITLE
Immersive mode can be disabled for default cast player page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ publishing {
         ccl(MavenPublication) {
             groupId 'com.brightcove'
             artifactId 'ccl'
-            version '1.0.3'
+            version '1.0.4'
             artifact("$buildDir/outputs/aar/BARC-CCL-JOB1-release.aar")
         }
     }

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/VideoCastManager.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/VideoCastManager.java
@@ -146,6 +146,7 @@ public class VideoCastManager extends BaseCastManager
     public static final String EXTRA_SHOULD_START = "shouldStart";
     public static final String EXTRA_NEXT_PREVIOUS_VISIBILITY_POLICY = "nextPrevPolicy";
     public static final String EXTRA_CUSTOM_DATA = "customData";
+    public static final String EXTRA_IMMERSIVE_MODE = "immersiveMode";
     public static final double DEFAULT_VOLUME_STEP = 0.05;
     private static final long PROGRESS_UPDATE_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
     private double mVolumeStep = DEFAULT_VOLUME_STEP;
@@ -411,11 +412,26 @@ public class VideoCastManager extends BaseCastManager
      */
     public void startVideoCastControllerActivity(Context context, Bundle mediaWrapper, int position,
             boolean shouldStart, JSONObject customData) {
+        startVideoCastControllerActivity(context, mediaWrapper, position, shouldStart, true, customData);
+    }
+
+    /**
+     * Launches the {@link VideoCastControllerActivity} that provides a default Cast Player page.
+     * @param context The context to use for starting the activity
+     * @param mediaWrapper a bundle wrapper for the media that is or will be casted
+     * @param position Starting point, in milliseconds,  of the media playback
+     * @param shouldStart indicates if the remote playback should start after launching the new page
+     * @param immersiveMode indicates if the player page should be launched in immersive mode.
+     * @param customData Optional {@link JSONObject}
+     */
+    public void startVideoCastControllerActivity(Context context, Bundle mediaWrapper, int position,
+             boolean shouldStart, boolean immersiveMode, JSONObject customData) {
         Intent intent = new Intent(context, VideoCastControllerActivity.class);
         intent.putExtra(EXTRA_MEDIA, mediaWrapper);
         intent.putExtra(EXTRA_START_POINT, position);
         intent.putExtra(EXTRA_SHOULD_START, shouldStart);
         intent.putExtra(EXTRA_NEXT_PREVIOUS_VISIBILITY_POLICY, mNextPreviousVisibilityPolicy);
+        intent.putExtra(EXTRA_IMMERSIVE_MODE, immersiveMode);
         if (customData != null) {
             intent.putExtra(EXTRA_CUSTOM_DATA, customData.toString());
         }
@@ -463,8 +479,13 @@ public class VideoCastManager extends BaseCastManager
      */
     public void startVideoCastControllerActivity(Context context,
             MediaInfo mediaInfo, int position, boolean shouldStart) {
+        startVideoCastControllerActivity(context, mediaInfo, position, shouldStart, true);
+    }
+
+    public void startVideoCastControllerActivity(Context context, MediaInfo mediaInfo, int position,
+                                                 boolean shouldStart, boolean immersiveMode) {
         startVideoCastControllerActivity(context, Utils.mediaInfoToBundle(mediaInfo), position,
-                shouldStart);
+                shouldStart, immersiveMode, null);
     }
 
     /**

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/player/VideoCastControllerFragment.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/player/VideoCastControllerFragment.java
@@ -111,7 +111,6 @@ public class VideoCastControllerFragment extends Fragment implements
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        setImmersive();
         mCastConsumer = new MyCastConsumer();
         Bundle bundle = getArguments();
         if (bundle == null) {
@@ -119,6 +118,10 @@ public class VideoCastControllerFragment extends Fragment implements
         }
         Bundle extras = bundle.getBundle(EXTRAS);
         Bundle mediaWrapper = extras.getBundle(VideoCastManager.EXTRA_MEDIA);
+
+        // Set immersive mode
+        if (extras.getBoolean(VideoCastManager.EXTRA_IMMERSIVE_MODE, false))
+            setImmersive();
 
         // Retain this fragment across configuration changes.
         setRetainInstance(true);


### PR DESCRIPTION
By default, the default cast player screen is displayed using immersive mode.  This pull request introduces a way to override that behavior.
