### PR TITLE
Add preDisconnect callback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ publishing {
         ccl(MavenPublication) {
             groupId 'com.brightcove'
             artifactId 'ccl'
-            version '1.0.4'
+            version '1.0.5'
             artifact("$buildDir/outputs/aar/BARC-CCL-JOB1-release.aar")
         }
     }

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/BaseCastManager.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/BaseCastManager.java
@@ -240,6 +240,7 @@ public abstract class BaseCastManager
         if (mSelectedCastDevice == null) {
             return;
         }
+        onPreDisconnect();
         mSelectedCastDevice = null;
         mDeviceName = null;
         LOGD(TAG, "mConnectionSuspended: " + mConnectionSuspended);
@@ -889,6 +890,11 @@ public abstract class BaseCastManager
 
     }
 
+    protected void onPreDisconnect() {
+        for (BaseCastConsumer consumer : mBaseCastConsumers) {
+            consumer.onPreDisconnect();
+        }
+    }
     /*
      * Note: this is not called by the SDK anymore but this library calls this in the appropriate
      * time.

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/callbacks/BaseCastConsumer.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/callbacks/BaseCastConsumer.java
@@ -44,6 +44,11 @@ public interface BaseCastConsumer extends OnFailedListener {
     void onConnectionSuspended(int cause);
 
     /**
+     * Called right before a device is disconnected
+     */
+    void onPreDisconnect();
+
+    /**
      * Called when a device is disconnected
      */
     void onDisconnected();

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/callbacks/BaseCastConsumerImpl.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/callbacks/BaseCastConsumerImpl.java
@@ -31,6 +31,10 @@ public class BaseCastConsumerImpl implements BaseCastConsumer {
     }
 
     @Override
+    public void onPreDisconnect() {
+    }
+
+    @Override
     public void onDisconnected() {
     }
 


### PR DESCRIPTION
Add a preDisconnect callback to VideoCastManager.  This is called right before the app is disconnected from the casting device.  It allows the callback a chance to get the player's status before casting is stopped.
